### PR TITLE
chore: add Renovate and Dependabot dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions"]
+}


### PR DESCRIPTION
Could be handy, since dependabot and renovate support the Hugo static website ecosystem.

- renovate.json: Renovate Bot configuration
- .github/dependabot.yml: GitHub Dependabot configuration


Do not forget to set-up renovate for other dependencies and repo's as well via https://developer.mend.io/.  Authorize that with your Github account.

For Renovate to do its job, it should say something like "onboarded" or "active".

You can do this for your other repo's as well! Helps a lot in dependency management..